### PR TITLE
fix call which return a set

### DIFF
--- a/eve_agents/src/main/java/com/almende/eve/agent/AgentProxyFactory.java
+++ b/eve_agents/src/main/java/com/almende/eve/agent/AgentProxyFactory.java
@@ -14,6 +14,7 @@ import com.almende.eve.transform.rpc.formats.JSONRPCException;
 import com.almende.eve.transform.rpc.formats.JSONRPCException.CODE;
 import com.almende.util.TypeUtil;
 import com.almende.util.callback.SyncCallback;
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * A factory for creating AgentProxy objects.
@@ -48,7 +49,7 @@ public final class AgentProxyFactory {
 					public Object invoke(final Object proxy,
 							final Method method, final Object[] args) {
 						
-						final SyncCallback<Object> callback = new SyncCallback<Object>() {
+						final SyncCallback<JsonNode> callback = new SyncCallback<JsonNode>() {
 						};
 						try {
 							sender.call(receiverUrl, method, args, callback);


### PR DESCRIPTION
Calls which return a Set break, because a set or list can't be converted to java Object, so it automatically becomes a list which gives conversion errors with Sets. A JsonNode can be converted to a list.
